### PR TITLE
fix(types): explicitly import the URL type

### DIFF
--- a/create-require.d.ts
+++ b/create-require.d.ts
@@ -1,1 +1,3 @@
+import { URL } from 'url';
+
 export default function createRequire (filename: string | URL): NodeRequire;


### PR DESCRIPTION
**What's the problem this PR addresses?**

The URL type isn't explicitly imported which means people without `skipLibCheck: true` needs to add DOM to their `lib` config

Fixes https://github.com/cucumber/cucumber-js/pull/1413#discussion_r531024507

**How did you fix it?**

Explicitly import the URL type